### PR TITLE
fix: add @ts-nocheck to tui utils

### DIFF
--- a/coding-agent/package.nix
+++ b/coding-agent/package.nix
@@ -42,26 +42,26 @@ buildNpmPackage {
   ];
 
   preBuild = ''
-        find packages -name "package.json" -exec sed -i \
-          -e 's/--watch --preserveWatchOutput//g' \
-          {} \;
+    find packages -name "package.json" -exec sed -i \
+      -e 's/--watch --preserveWatchOutput//g' \
+      {} \;
 
-        for f in packages/ai/src/models.ts packages/agent/src/agent.ts packages/tui/src/utils.ts; do
-          [ -f "$f" ] && echo '// @ts-nocheck' | cat - "$f" > tmp && mv tmp "$f"
-        done
+    for f in packages/ai/src/models.ts packages/agent/src/agent.ts packages/tui/src/utils.ts; do
+      [ -f "$f" ] && echo '// @ts-nocheck' | cat - "$f" > tmp && mv tmp "$f"
+    done
 
-        substituteInPlace packages/coding-agent/src/modes/interactive/interactive-mode.ts \
-          --replace-fail '		const action = theme.fg("accent", `''${APP_NAME} update`);
-    		const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
-                         '		const action = theme.fg("accent", `https://github.com/lukasl-dev/pi-mono.nix/releases/tag/v''${newVersion}`);
-    		const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
-          --replace-fail '"https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md"' \
-                         '`https://github.com/badlogic/pi-mono/blob/v''${newVersion}/packages/coding-agent/CHANGELOG.md`'
+    substituteInPlace packages/coding-agent/src/modes/interactive/interactive-mode.ts \
+      --replace-fail '		const action = theme.fg("accent", `''${APP_NAME} update`);
+    const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
+                     '		const action = theme.fg("accent", `https://github.com/lukasl-dev/pi-mono.nix/releases/tag/v''${newVersion}`);
+    const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
+      --replace-fail '"https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md"' \
+                     '`https://github.com/badlogic/pi-mono/blob/v''${newVersion}/packages/coding-agent/CHANGELOG.md`'
 
-        cp ${../models.generated.ts} packages/ai/src/models.generated.ts
+    cp ${../models.generated.ts} packages/ai/src/models.generated.ts
 
-        substituteInPlace packages/ai/package.json \
-          --replace-fail 'npm run generate-models && ' '''
+    substituteInPlace packages/ai/package.json \
+      --replace-fail 'npm run generate-models && ' '''
   '';
 
   buildPhase = ''
@@ -96,6 +96,6 @@ buildNpmPackage {
     homepage = "https://github.com/badlogic/pi-mono";
     license = lib.licenses.mit;
     mainProgram = "pi";
-    maintainers = [ ];
+    maintainers = [];
   };
 }

--- a/coding-agent/package.nix
+++ b/coding-agent/package.nix
@@ -42,26 +42,26 @@ buildNpmPackage {
   ];
 
   preBuild = ''
-    find packages -name "package.json" -exec sed -i \
-      -e 's/--watch --preserveWatchOutput//g' \
-      {} \;
+        find packages -name "package.json" -exec sed -i \
+          -e 's/--watch --preserveWatchOutput//g' \
+          {} \;
 
-    for f in packages/ai/src/models.ts packages/agent/src/agent.ts; do
-      [ -f "$f" ] && echo '// @ts-nocheck' | cat - "$f" > tmp && mv tmp "$f"
-    done
+        for f in packages/ai/src/models.ts packages/agent/src/agent.ts packages/tui/src/utils.ts; do
+          [ -f "$f" ] && echo '// @ts-nocheck' | cat - "$f" > tmp && mv tmp "$f"
+        done
 
-    substituteInPlace packages/coding-agent/src/modes/interactive/interactive-mode.ts \
-      --replace-fail '		const action = theme.fg("accent", `''${APP_NAME} update`);
-		const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
-                     '		const action = theme.fg("accent", `https://github.com/lukasl-dev/pi-mono.nix/releases/tag/v''${newVersion}`);
-		const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
-      --replace-fail '"https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md"' \
-                     '`https://github.com/badlogic/pi-mono/blob/v''${newVersion}/packages/coding-agent/CHANGELOG.md`'
+        substituteInPlace packages/coding-agent/src/modes/interactive/interactive-mode.ts \
+          --replace-fail '		const action = theme.fg("accent", `''${APP_NAME} update`);
+    		const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
+                         '		const action = theme.fg("accent", `https://github.com/lukasl-dev/pi-mono.nix/releases/tag/v''${newVersion}`);
+    		const updateInstruction = theme.fg("muted", `New version ''${newVersion} is available. Run `) + action;' \
+          --replace-fail '"https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md"' \
+                         '`https://github.com/badlogic/pi-mono/blob/v''${newVersion}/packages/coding-agent/CHANGELOG.md`'
 
-    cp ${../models.generated.ts} packages/ai/src/models.generated.ts
+        cp ${../models.generated.ts} packages/ai/src/models.generated.ts
 
-    substituteInPlace packages/ai/package.json \
-      --replace-fail 'npm run generate-models && ' '''
+        substituteInPlace packages/ai/package.json \
+          --replace-fail 'npm run generate-models && ' '''
   '';
 
   buildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,14 @@
         }
       );
 
+      formatter = forEachSystem (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.alejandra
+      );
+
       overlays = {
         default = _final: prev: {
           pi-coding-agent = self.packages.${prev.stdenv.hostPlatform.system}.coding-agent;


### PR DESCRIPTION
I get a build error from time to time. Mostly when trying to make the flake follow my NixOS nixpkgs

```sh
warning: Git tree '/home/dami/soft/src/nix/original-pi-mono.nix' is dirty
error: Cannot build '/nix/store/slqvdr39s043ndfkdhhdw42ilblfdp8g-pi-coding-agent-0.72.1.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/86dwr4v3lnk9gkvv3xdlvwrbzipgglvw-pi-coding-agent-0.72.1
       Last 25 log lines:
       > npm error path /build/source/packages/tui
       > npm error workspace @mariozechner/pi-tui@0.72.1
       > npm error location /build/source/packages/tui
       > npm error command failed
       > npm error command sh -c tsgo -p tsconfig.build.json
       >
       >
       > > @mariozechner/pi-ai@0.72.1 build
       > > tsgo -p tsconfig.build.json
       >
       >
       > > @mariozechner/pi-agent-core@0.72.1 build
       > > tsgo -p tsconfig.build.json
       >
       >
       > > @mariozechner/pi-coding-agent@0.72.1 build
       > > tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js && npm run copy-assets
       >
       > npm warn Unknown env config "nodedir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm warn Unknown env config "platform". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm warn Unknown env config "arch". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       >
       > > @mariozechner/pi-coding-agent@0.72.1 copy-assets
       > > shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/
       >
       For full logs, run:
         nix log /nix/store/slqvdr39s043ndfkdhhdw42ilblfdp8g-pi-coding-agent-0.72.1.drv
```

a further run of `nix log /nix/store/slqvdr39s043ndfkdhhdw42ilblfdp8g-pi-coding-agent-0.72.1.drv` give me:

```sh

> @mariozechner/pi-tui@0.72.1 build
> tsgo -p tsconfig.build.json

src/utils.ts:32:100 - error TS1501: This regular expression flag is only available when targeting 'es2024' or later.

32 const zeroWidthRegex = /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v;
                                                                                                      ~

src/utils.ts:33:113 - error TS1501: This regular expression flag is only available when targeting 'es2024' or later.

33 const leadingNonPrintingRegex = /^[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]+/v;
                                                                                                                   ~

src/utils.ts:34:40 - error TS1501: This regular expression flag is only available when targeting 'es2024' or later.

34 const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
                                          ~


Found 3 errors in the same file, starting at: src/utils.ts:32

npm error Lifecycle script `build` failed with error:
npm error code 1
npm error path /build/source/packages/tui
npm error workspace @mariozechner/pi-tui@0.72.1
npm error location /build/source/packages/tui
npm error command failed
npm error command sh -c tsgo -p tsconfig.build.json


> @mariozechner/pi-ai@0.72.1 build
> tsgo -p tsconfig.build.json


> @mariozechner/pi-agent-core@0.72.1 build
> tsgo -p tsconfig.build.json


> @mariozechner/pi-coding-agent@0.72.1 build
> tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js && npm run copy-assets

npm warn Unknown env config "nodedir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
npm warn Unknown env config "platform". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
npm warn Unknown env config "arch". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.

> @mariozechner/pi-coding-agent@0.72.1 copy-assets
> shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/inter>

lines 93-142/142 (END)

```