### PR TITLE
Use L+ in tmpfile rule to force config updates

### DIFF
--- a/coding-agent/module.nix
+++ b/coding-agent/module.nix
@@ -244,7 +244,7 @@ in
           rules = [
             "d %h/.pi 0700 - - -"
             "d %h/.pi/agent 0700 - - -"
-            "L %h/.pi/agent/models.json - - - - ${cfg.models}"
+            "L+ %h/.pi/agent/models.json - - - - ${cfg.models}"
           ];
         in
         lib.mkMerge [


### PR DESCRIPTION
Updated the systemd-tmpfiles rule for the models.json from L to L+ to ensure is written even if the file already exists. This prevents models.json files from previous generations to block updates, which could leave users with outdaded configs.