### PR TITLE
Respect selected branch on workflow_dispatch manual trigger

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,7 +3,7 @@ name: Cron
 on:
   workflow_dispatch:
   schedule:
-    - cron: '17 4 * * *'
+    - cron: "17 4 * * *"
 
 permissions:
   contents: write
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.ref }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -33,7 +33,7 @@ jobs:
         uses: cachix/cachix-action@v14
         with:
           name: pi
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Update version and models
         id: update
@@ -41,7 +41,7 @@ jobs:
 
       - name: Commit and push changes
         env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -71,7 +71,7 @@ jobs:
             fi
           fi
 
-          git push origin "HEAD:${DEFAULT_BRANCH}"
+          git push origin "HEAD:${BRANCH}"
           if [[ "$push_tag" == "true" ]]; then
             git push origin "refs/tags/${version}"
           fi


### PR DESCRIPTION
Use github.ref for checkout and github.ref_name for push instead of hardcoded github.event.repository.default_branch, so manually triggered runs use the branch selected in the UI.